### PR TITLE
Change BP_JVM_VERSION default from 11.* to 11

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -50,7 +50,7 @@ launch      = true
 [[metadata.configurations]]
 name        = "BP_JVM_VERSION"
 description = "the Java version"
-default     = "11.*"
+default     = "11"
 build       = true
 
 [[metadata.configurations]]


### PR DESCRIPTION
This will not change buildpack behavior. In the future we would like to change the usage of the config value to accept JVM spec versions like 8 and 11 but not semver matchers for full openjdk vesion. This new default will work in both cases.

Signed-off-by: Emily Casey <ecasey@vmware.com>
