### PR TITLE
Configure GraalVM CPE & PURL updates

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -20,6 +20,8 @@ dependencies:
 - name:            JDK 8
   id:              jdk
   version_pattern: "8\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "update[\\d]+"
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/graalvm-dependency:main
   with:
     glob:    graalvm-ce-java8-linux-amd64-.+.tar.gz
@@ -28,6 +30,8 @@ dependencies:
 - name:            Native Image 8
   id:              native-image-svm
   version_pattern: "8\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/graalvm-dependency:main
   with:
     glob:    native-image-installable-svm-java8-linux-amd64-.+.jar
@@ -36,6 +40,7 @@ dependencies:
 - name:            JDK 11
   id:              jdk
   version_pattern: "11\\.[\\d]+\\.[\\d]+"
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/graalvm-dependency:main
   with:
     glob:    graalvm-ce-java11-linux-amd64-.+.tar.gz
@@ -44,6 +49,8 @@ dependencies:
 - name:            Native Image 11
   id:              native-image-svm
   version_pattern: "11\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/graalvm-dependency:main
   with:
     glob:    native-image-installable-svm-java11-linux-amd64-.+.jar
@@ -52,6 +59,7 @@ dependencies:
 - name:            JDK 17
   id:              jdk
   version_pattern: "17\\.[\\d]+\\.[\\d]+"
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/graalvm-dependency:main
   with:
     glob:    graalvm-ce-java17-linux-amd64-.+.tar.gz
@@ -60,6 +68,8 @@ dependencies:
 - name:            Native Image 17
   id:              native-image-svm
   version_pattern: "17\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/graalvm-dependency:main
   with:
     glob:    native-image-installable-svm-java17-linux-amd64-.+.jar

--- a/.github/workflows/update-jdk-11.yml
+++ b/.github/workflows/update-jdk-11.yml
@@ -91,7 +91,7 @@ jobs:
                 CPE_PATTERN: ""
                 ID: jdk
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-jdk-17.yml
+++ b/.github/workflows/update-jdk-17.yml
@@ -91,7 +91,7 @@ jobs:
                 CPE_PATTERN: ""
                 ID: jdk
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-jdk-8.yml
+++ b/.github/workflows/update-jdk-8.yml
@@ -88,10 +88,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: update[\d]+
                 ID: jdk
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-native-image-11.yml
+++ b/.github/workflows/update-native-image-11.yml
@@ -88,10 +88,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 ID: native-image-svm
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-native-image-17.yml
+++ b/.github/workflows/update-native-image-17.yml
@@ -88,10 +88,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 ID: native-image-svm
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-native-image-8.yml
+++ b/.github/workflows/update-native-image-8.yml
@@ -88,10 +88,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 ID: native-image-svm
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -121,7 +121,7 @@ api = "0.7"
     name = "JAVA_TOOL_OPTIONS"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:oracle:graalvm:21.2.0:*:*:*:community:*:*:*", "cpe:2.3:a:oracle:jdk:1.8.0:update302:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:oracle:jdk:1.8.0:update302:*:*:*:*:*:*:*"]
     id = "jdk"
     name = "GraalVM JDK"
     purl = "pkg:generic/graalvm-jdk@21.2.0"
@@ -135,7 +135,7 @@ api = "0.7"
       uri = "https://openjdk.java.net/legal/gplv2+ce.html"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:oracle:graalvm:21.2.0:*:*:*:community:*:*:*"]
+    cpes = ["cpe:2.3:a:oracle:graalvm:21.2.0:*:*:*:*:*:*:*"]
     id = "native-image-svm"
     name = "GraalVM Native Image Substrate VM"
     purl = "pkg:generic/graalvm-svm@21.2.0"
@@ -149,7 +149,7 @@ api = "0.7"
       uri = "https://openjdk.java.net/legal/gplv2+ce.html"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:oracle:graalvm:21.3.0:*:*:*:community:*:*:*", "cpe:2.3:a:oracle:jdk:11.0.13:*:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:oracle:jdk:11.0.13:*:*:*:*:*:*:*:*"]
     id = "jdk"
     name = "GraalVM JDK"
     purl = "pkg:generic/graalvm-jdk@21.3.0"
@@ -163,7 +163,7 @@ api = "0.7"
       uri = "https://openjdk.java.net/legal/gplv2+ce.html"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:oracle:graalvm:21.3.0:*:*:*:community:*:*:*"]
+    cpes = ["cpe:2.3:a:oracle:graalvm:21.3.0:*:*:*:*:*:*:*"]
     id = "native-image-svm"
     name = "GraalVM Native Image Substrate VM"
     purl = "pkg:generic/graalvm-svm@21.3.0"
@@ -177,7 +177,7 @@ api = "0.7"
       uri = "https://openjdk.java.net/legal/gplv2+ce.html"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:oracle:graalvm:21.3.0:*:*:*:community:*:*:*", "cpe:2.3:a:oracle:jdk:17.0.1:*:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:oracle:jdk:17.0.1:*:*:*:*:*:*:*:*"]
     id = "jdk"
     name = "GraalVM JDK"
     purl = "pkg:generic/graalvm-jdk@21.3.0"
@@ -191,7 +191,7 @@ api = "0.7"
       uri = "https://openjdk.java.net/legal/gplv2+ce.html"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:oracle:graalvm:21.3.0:*:*:*:community:*:*:*"]
+    cpes = ["cpe:2.3:a:oracle:graalvm:21.3.0:*:*:*:*:*:*:*"]
     id = "native-image-svm"
     name = "GraalVM Native Image Substrate VM"
     purl = "pkg:generic/graalvm-svm@21.3.0"


### PR DESCRIPTION
## Summary

- Changes the CPEs to only use the JDK CPE for JDKs, substrate VM continues using the GraalVM CPE
- Adds CPE & PURL patterns for updating these as these are different from the version we specify. This is for historical reasons & has to do with the version swuashing that takes place to make everything a semver.
- Updates all the workflows.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
