### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/graalvm`
 
-The Paketo GraalVM Buildpack is a Cloud Native Buildpack that provides the GraalVM implementations of the JDK and GraalVM [Native Image builder][native-image].
+The Paketo Buildpack for GraalVM is a Cloud Native Buildpack that provides the GraalVM implementations of the JDK and GraalVM [Native Image builder][native-image].
 
 This buildpack is designed to work in collaboration with other buildpacks which request contributions of JREs, JDKs, or Native Image builder.
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/graalvm"
   id = "paketo-buildpacks/graalvm"
   keywords = ["java", "jvm", "jre", "jdk", "native-image"]
-  name = "Paketo GraalVM Buildpack"
+  name = "Paketo Buildpack for GraalVM"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo GraalVM Buildpack' to 'Paketo Buildpack for GraalVM'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
