### PR TITLE
Add support for Java 19

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -55,3 +55,22 @@ dependencies:
     glob:    native-image-installable-svm-java17-linux-amd64-.+.jar
     token:   ${{ secrets.JAVA_GITHUB_TOKEN }}
     version: 17
+- name:            JDK 19
+  id:              jdk
+  version_pattern: "19\\.[\\d]+\\.[\\d]+"
+  purl_pattern:    "19\\.[\\d]+\\.[\\d]+"
+  uses:            docker://ghcr.io/paketo-buildpacks/actions/graalvm-dependency:main
+  with:
+    glob:    graalvm-ce-java19-linux-amd64-.+.tar.gz
+    token:   ${{ secrets.JAVA_GITHUB_TOKEN }}
+    version: 19
+- name:            Native Image 19
+  id:              native-image-svm
+  version_pattern: "19\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.?[\\d]?"
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.?[\\d]?"
+  uses:            docker://ghcr.io/paketo-buildpacks/actions/graalvm-dependency:main
+  with:
+    glob:    native-image-installable-svm-java19-linux-amd64-.+.jar
+    token:   ${{ secrets.JAVA_GITHUB_TOKEN }}
+    version: 19

--- a/.github/workflows/pb-update-jdk-19.yml
+++ b/.github/workflows/pb-update-jdk-19.yml
@@ -1,0 +1,112 @@
+name: Update JDK 19
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v3
+              with:
+                go-version: "1.18"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/graalvm-dependency:main
+              with:
+                glob: graalvm-ce-java19-linux-amd64-.+.tar.gz
+                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                version: 19
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |-
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
+              env:
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: ""
+                ID: jdk
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: 19\.[\d]+\.[\d]+
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: 19\.[\d]+\.[\d]+
+            - uses: peter-evans/create-pull-request@v4
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `JDK 19` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/jdk-19
+                commit-message: |-
+                    Bump JDK 19 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps JDK 19 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump JDK 19 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.JAVA_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-native-image-19.yml
+++ b/.github/workflows/pb-update-native-image-19.yml
@@ -1,0 +1,112 @@
+name: Update Native Image 19
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v3
+              with:
+                go-version: "1.18"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/graalvm-dependency:main
+              with:
+                glob: native-image-installable-svm-java19-linux-amd64-.+.jar
+                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                version: 19
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |-
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
+              env:
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.?[\d]?'
+                ID: native-image-svm
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.?[\d]?'
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: 19\.[\d]+\.[\d]+
+            - uses: peter-evans/create-pull-request@v4
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `Native Image 19` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/native-image-19
+                commit-message: |-
+                    Bump Native Image 19 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps Native Image 19 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump Native Image 19 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.JAVA_GITHUB_TOKEN }}

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 the original author or authors.
+# Copyright 2018-2022 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -183,6 +183,34 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
     uri = "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/native-image-installable-svm-java17-linux-amd64-22.3.0.jar"
     version = "17.0.5"
+
+    [[metadata.dependencies.licenses]]
+      type = "GPL-2.0 WITH Classpath-exception-2.0"
+      uri = "https://openjdk.java.net/legal/gplv2+ce.html"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:oracle:jdk:19.0.1:*:*:*:*:*:*:*:*"]
+    id = "jdk"
+    name = "GraalVM JDK"
+    purl = "pkg:generic/graalvm-jdk@19.0.1"
+    sha256 = "ae9cb1afe327d49a8c049ab588090838e622d9d832b9a1c0523821a6f38d6b4d"
+    stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
+    uri = "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/graalvm-ce-java19-linux-amd64-22.3.0.tar.gz"
+    version = "19.0.1"
+
+    [[metadata.dependencies.licenses]]
+      type = "GPL-2.0 WITH Classpath-exception-2.0"
+      uri = "https://openjdk.java.net/legal/gplv2+ce.html"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:oracle:graalvm:22.3.0:*:*:*:*:*:*:*"]
+    id = "native-image-svm"
+    name = "GraalVM Native Image Substrate VM"
+    purl = "pkg:generic/graalvm-svm@22.3.0"
+    sha256 = "55b341ca1bca5219aafa8ed7c8a2273b81d184dd600d8261c837fc32d2dedae5"
+    stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
+    uri = "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/native-image-installable-svm-java19-linux-amd64-22.3.0.jar"
+    version = "19.0.1"
 
     [[metadata.dependencies.licenses]]
       type = "GPL-2.0 WITH Classpath-exception-2.0"


### PR DESCRIPTION
## Summary

This PR adds support for Java 19 in the GraalVM buildpack. GraalVM lists Java 19 support as experimental at the moment, but we'll add it for those wishing to experiment. Java 19 is not a long term support release and the buildpacks will remove support for Java 19  when upstream removes support.

https://www.graalvm.org/release-notes/22_3/#platform-updates

## Use Cases

Experiment with Java 19.
