### PR TITLE
Fixed GraalVM Release Schedule Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This buildpack is designed to work in collaboration with other buildpacks which 
 
 ## Upstream releases
 
-The Paketo team will do its best to provide the latest GraalVM implementations of the JDK and GraalVM, whenever they become available, according to this schedule: https://www.graalvm.org/release-notes/release-calendar/#planned-releases
+The Paketo team will do its best to provide the latest GraalVM implementations of the JDK and GraalVM, whenever they become available, according to the [GraalVM Release Calendar](https://www.graalvm.org/release-calendar/).
 
 ## Behavior
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR aims to fix a broken URL of the GraalVM release schedule by changing it to the current release calendar.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
